### PR TITLE
Add `NotGranted` to `PermissionState` for Android

### DIFF
--- a/permissions/src/androidMain/kotlin/dev/icerock/moko/permissions/PermissionsControllerImpl.kt
+++ b/permissions/src/androidMain/kotlin/dev/icerock/moko/permissions/PermissionsControllerImpl.kt
@@ -91,10 +91,10 @@ class PermissionsControllerImpl(
         val resolverFragment: ResolverFragment = getOrCreateResolverFragment(fragmentManager)
 
         val isAllRequestRationale: Boolean = permissions.all {
-            !resolverFragment.shouldShowRequestPermissionRationale(it)
+            resolverFragment.shouldShowRequestPermissionRationale(it)
         }
-        return if (isAllRequestRationale) PermissionState.NotDetermined
-        else PermissionState.Denied
+        return if (isAllRequestRationale) PermissionState.Denied
+        else PermissionState.NotGranted
     }
 
     override fun openAppSettings() {

--- a/permissions/src/commonMain/kotlin/dev/icerock/moko/permissions/PermissionState.kt
+++ b/permissions/src/commonMain/kotlin/dev/icerock/moko/permissions/PermissionState.kt
@@ -5,8 +5,27 @@
 package dev.icerock.moko.permissions
 
 enum class PermissionState {
+
+    /**
+     * Starting state for each permission.
+     */
     NotDetermined,
+
+    /**
+     * Android-only. This could mean [NotDetermined] or [DeniedAlways], but the OS doesn't
+     * expose which of the two it is in all scenarios.
+     */
+    NotGranted,
+
     Granted,
+
+    /**
+     * Android-only.
+     */
     Denied,
+
+    /**
+     * On Android only applicable to Push Notifications.
+     */
     DeniedAlways
 }

--- a/permissions/src/commonMain/kotlin/dev/icerock/moko/permissions/PermissionsController.kt
+++ b/permissions/src/commonMain/kotlin/dev/icerock/moko/permissions/PermissionsController.kt
@@ -24,12 +24,13 @@ expect interface PermissionsController {
 
     /**
      * Returns current state of permission. Can be suspended because on
-     * android detection of Denied/NotDetermined case require binded FragmentManager.
+     * Android detection of `Denied`/`NotDetermined` requires a bound FragmentManager.
      *
      * @param permission state of what permission we want
      *
-     * @return current state. On Android can't be DeniedAlways (except push notifications).
-     * On iOS can't be Denied.
+     * @return current state. On Android can't be `DeniedAlways` (except push notifications).
+     * On iOS can't be `Denied`.
+     * @see PermissionState for a detailed description.
      */
     suspend fun getPermissionState(permission: Permission): PermissionState
 

--- a/sample/compose-android-app/src/main/java/com/icerockdev/MainActivity.kt
+++ b/sample/compose-android-app/src/main/java/com/icerockdev/MainActivity.kt
@@ -4,7 +4,9 @@ import android.os.Bundle
 import androidx.activity.compose.setContent
 import androidx.appcompat.app.AppCompatActivity
 import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.Button
@@ -17,6 +19,9 @@ import androidx.compose.material.Text
 import androidx.compose.material.rememberScaffoldState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
@@ -29,6 +34,7 @@ import dev.icerock.moko.mvvm.getViewModel
 import dev.icerock.moko.permissions.DeniedAlwaysException
 import dev.icerock.moko.permissions.DeniedException
 import dev.icerock.moko.permissions.Permission
+import dev.icerock.moko.permissions.PermissionState
 import dev.icerock.moko.permissions.PermissionsController
 import dev.icerock.moko.permissions.compose.BindEffect
 import kotlinx.coroutines.launch
@@ -100,16 +106,20 @@ fun TestScreen(viewModel: SampleViewModel) {
     LaunchedEffect(true) {
         viewModel.eventsDispatcher.bind(lifecycleOwner, eventsListener)
     }
+    val permissionState by viewModel.permissionState.collectAsState()
 
     BindEffect(viewModel.permissionsController)
 
     Scaffold(scaffoldState = scaffoldState) {
-        Box(
+        Column(
             modifier = Modifier
                 .fillMaxSize()
                 .padding(it),
-            contentAlignment = Alignment.Center
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center
         ) {
+            Text("Permission state: $permissionState")
+
             Button(
                 onClick = viewModel::onRequestPermissionButtonPressed,
                 content = { Text("Request permission") }


### PR DESCRIPTION
Here's one idea to fix the issue with [deny and don't ask again] returning an incorrect state (#104), by adding a new state for Android: `NotGranted`. It's the most accurate description of the situation: it could be `NotDetermined` or `DeniedAlways` but there's  no way to determine the difference between [deny] and [always deny] when requesting the state. One has to keep track of whether a permission has been requested in the app already, so that's up to consumers.

This change does not affect iOS' behaviour, nor `providePermission()`/`isPermissionGranted()` behaviour. Only on for requesting the current state on Android.

**Alternative solution** would be to add no different state, but make Android return `Denied` by default. Benefit is that the state enum doesn't change and existing apps would be likely to keep working. Downside is that the default state is `Denied` and that could look like a bug. But again, a documentation update helps.

## Before

See screen capture in #104

## After

![MokoPermissionStateBugAndroidFixed](https://github.com/icerockdev/moko-permissions/assets/3338890/f0bdb5fc-ceda-46cf-9220-231351817137)
