### PR TITLE
Fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ All development (both new features and bug fixes) is performed in `develop` bran
 
 The `develop` branch is pushed to `master` during release.
 
-More detailed guide for contributers see in [contributing guide](CONTRIBUTING.md).
+More detailed guide for contributors see in [contributing guide](CONTRIBUTING.md).
 
 ## License
         


### PR DESCRIPTION
This pull request includes a minor correction to a typo in the `README.md` file. The word "contributers" was corrected to "contributors" for improved clarity.