### PR TITLE
fix iOS background location permission state and requesting

### DIFF
--- a/permissions-location/src/iosMain/kotlin/dev/icerock/moko/permissions/location/LocationManagerDelegate.kt
+++ b/permissions-location/src/iosMain/kotlin/dev/icerock/moko/permissions/location/LocationManagerDelegate.kt
@@ -18,10 +18,16 @@ internal class LocationManagerDelegate : NSObject(), CLLocationManagerDelegatePr
         locationManager.delegate = this
     }
 
-    fun requestLocationAccess(callback: (CLAuthorizationStatus) -> Unit) {
+    fun requestWhenInUseAuthorization(callback: (CLAuthorizationStatus) -> Unit) {
         this.callback = callback
 
         locationManager.requestWhenInUseAuthorization()
+    }
+
+    fun requestAlwaysAuthorization(callback: (CLAuthorizationStatus) -> Unit) {
+        this.callback = callback
+
+        locationManager.requestAlwaysAuthorization()
     }
 
     override fun locationManager(

--- a/permissions-location/src/iosMain/kotlin/dev/icerock/moko/permissions/location/LocationPermission.ios.kt
+++ b/permissions-location/src/iosMain/kotlin/dev/icerock/moko/permissions/location/LocationPermission.ios.kt
@@ -30,8 +30,13 @@ private class LocationPermissionDelegate(
     override suspend fun getPermissionState(): PermissionState {
         val status: CLAuthorizationStatus = CLLocationManager.authorizationStatus()
         return when (status) {
-            kCLAuthorizationStatusAuthorizedAlways,
-            kCLAuthorizationStatusAuthorizedWhenInUse -> PermissionState.Granted
+            kCLAuthorizationStatusAuthorizedAlways -> PermissionState.Granted
+            kCLAuthorizationStatusAuthorizedWhenInUse -> {
+                when (permission) {
+                    is BackgroundLocationPermission -> PermissionState.NotGranted
+                    else -> PermissionState.Granted
+                }
+            }
 
             kCLAuthorizationStatusNotDetermined -> PermissionState.NotDetermined
             kCLAuthorizationStatusDenied,


### PR DESCRIPTION
Currently moko-permissions doesn't work for iOS when checking the state of background location permissions or requesting those permissions. 

This change fixes it so that when you request background location, if the `authorizationStatus` is not `always`, it will request always authorization. Additionally, if you check that state of background location permission and the authorization status is not `always` it will return `NotGranted`.